### PR TITLE
Fix process color

### DIFF
--- a/lib/themekit.ts
+++ b/lib/themekit.ts
@@ -39,7 +39,7 @@ export async function buildThemekit(
     do: (_, config) => {
       for (const file of config.files) {
         const filePath = resolve(process.cwd(), config.buildPath, file.destination)
-        const colorRe = /color\(.+\)/g
+        const colorRe = /color\((?!{).+\)/g
         let content = readFileSync(filePath, 'utf8')
         let executed = null
         while ((executed = colorRe.exec(content)) !== null) {


### PR DESCRIPTION
Раньше, `process-color` просто вытаскивал и заменял все формулы с `color(*)` из строки. Но есть загвоздка, в этой строке находится переменная `rawTokens` в которой может лежать формула с не разрезолвленным токеном.

```js
'button-view-default-fill-color-base': {
 name: 'button-view-default-fill-color-base',
  value: 'color(#C728B3 a(10%))',
  path: [ 'button', 'viewDefault', 'fillColor', 'base' ],
  comment: undefined,
  rawValue: 'color({button.viewAction.fillColor.base.value} a(10%))'
}
```

Так как раньше он просто делал `colorRe.exec(content)`, то он вытаскивал `color({button.viewAction.fillColor.base.value} a(10%))` и пытался запустить cssColorFn на нем, что приводило к ошибке.

Решение - пробегаться по объекту и заменять только `value`.